### PR TITLE
fix: mark unrated signs as non-failed

### DIFF
--- a/screens/signs/CardSign.jsx
+++ b/screens/signs/CardSign.jsx
@@ -69,7 +69,7 @@ const CardSign = ({ subject }) => {
     collectedPoints += Number.isNaN(mark) || maxScore === 0 ? 0 : mark;
 
     if (textStyle !== null) return;
-    if (isAbsent || mark < passScore) textStyle = styles.colorMark2;
+    if ((isAbsent || mark < passScore) && maxScore !== 0.0) textStyle = styles.colorMark2;
     else if (Number.isNaN(mark)) textStyle = styles.colorNoMark;
   });
   collectedPoints = collectedPoints.toFixed(1) % 1 === 0 ? collectedPoints.toFixed(0) : collectedPoints.toFixed(1);

--- a/screens/signs/Subject.jsx
+++ b/screens/signs/Subject.jsx
@@ -26,7 +26,8 @@ const Subject = ({ data }) => (
       return (
         <Text
           style={
-            Number.isNaN(info.mark) && info.isAbsent || info.mark < info.passScore
+            (Number.isNaN(info.mark) && info.isAbsent || info.mark < info.passScore) &&
+              (info.maxScore !== 0.0)
               ? styles.markFail
               : styles.markNeutral
           }


### PR DESCRIPTION
Вводные КТ учитываются как `0 баллов в рейтинг`, и завалив её фактически ничего не теряешь.
Но такие работы отмечали красным как саму КТ, так и дисциплину в целом, добавил проверку на наличие `балла в рейтинг`, теперь дисциплины зеленые :)
