### PR TITLE
refactor&fix: cleanup parser; elective subjects correct display

### DIFF
--- a/navigation/ServicesStackNavigator.jsx
+++ b/navigation/ServicesStackNavigator.jsx
@@ -1,9 +1,10 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 
+import About from '../screens/about/About';
 import Services from '../screens/services';
 import ShortTeachPlan from '../screens/shortTeachPlan';
-import About from '../screens/about/About';
+import TeacherTable from '../screens/teachers';
 
 const Stack = createNativeStackNavigator();
 
@@ -15,11 +16,9 @@ function ServicesStackNavigator() {
       }}
     >
       <Stack.Screen name="Сервисы" component={Services} />
-      <Stack.Screen
-        name="Учебный план"
-        component={ShortTeachPlan}
-      />
-      <Stack.Screen name={"О приложении"} component={About}/>
+      <Stack.Screen name="Учебный план" component={ShortTeachPlan} />
+      <Stack.Screen name="Преподаватели" component={TeacherTable} />
+      <Stack.Screen name="О приложении" component={About} />
     </Stack.Navigator>
   );
 }

--- a/screens/services/Menu.jsx
+++ b/screens/services/Menu.jsx
@@ -61,6 +61,11 @@ function Menu() {
           icon={<AntDesign name="profile" size={iconSize} color={iconColor} />}
           page="Учебный план"
         />
+        <Button
+          text="Преподаватели"
+          icon={<AntDesign name="team" size={iconSize} color={iconColor} />}
+          page="Преподаватели"
+        />
       </Row>
       <Row>
         <Button

--- a/screens/services/Menu.jsx
+++ b/screens/services/Menu.jsx
@@ -1,11 +1,11 @@
 import { AntDesign } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View, Linking } from 'react-native';
+import { Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { GLOBAL_STYLES } from '../../styles/styles';
 
-const iconSize = 36
+const iconSize = 36;
 const iconColor = '#000000'
 const styles = StyleSheet.create({
   buttonView: {
@@ -59,14 +59,14 @@ function Menu() {
         <Button
           text="Учебный план"
           icon={<AntDesign name="profile" size={iconSize} color={iconColor} />}
-          page={'Учебный план'}
+          page="Учебный план"
         />
       </Row>
       <Row>
         <Button
           text="Исходный код"
           icon={<AntDesign name="github" size={iconSize} color={iconColor} />}
-          link={"https://github.com/damego/ETIS-mobile"}
+          link="https://github.com/damego/ETIS-mobile"
         />
         <Button
           text="О приложении"

--- a/screens/teachers/Teacher.jsx
+++ b/screens/teachers/Teacher.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  Image,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+
+const styles = StyleSheet.create({
+  teacherNameView: {
+    marginLeft: '1%',
+    marginBottom: '1%',
+    paddingHorizontal: '1%',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  },
+  teacherNameText: {
+    marginTop: '1%',
+    fontSize: 16,
+    fontWeight: '400',
+  },
+  subjectInfoView: {
+    marginLeft: '2%',
+  },
+  subjectInfoText: {
+    fontSize: 13,
+    color: '#1c1c1c',
+  },
+  photoContainer: {
+    justifyContent: 'center',
+    padding: '1%',
+  },
+  photoStyle: {
+    width: 100,
+    height: 100,
+    borderRadius: 20,
+  },
+  container: {
+    flex: 2,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  teacherInfo: {
+    flex: 2,
+  },
+});
+
+const Teacher = ({ data: { cathedra, name, photo, photoTitle, subjectType } }) => (
+  <View style={styles.container}>
+    <View style={styles.teacherInfo}>
+      <View style={styles.teacherNameView}>
+        <Text style={styles.teacherNameText}>{name}</Text>
+      </View>
+
+      <View style={styles.subjectInfoView}>
+        <Text style={styles.subjectInfoText}>{cathedra}</Text>
+        <Text style={styles.subjectInfoText}>{subjectType}</Text>
+      </View>
+    </View>
+
+    <View style={styles.photoContainer}>
+      {/* Фотография загружена... */}
+      <TouchableWithoutFeedback onPress={() => ToastAndroid.show(photoTitle, ToastAndroid.SHORT)}>
+        <Image style={styles.photoStyle} src={`https://student.psu.ru/pls/stu_cus_et/${photo}`} />
+      </TouchableWithoutFeedback>
+    </View>
+  </View>
+);
+
+export default Teacher;

--- a/screens/teachers/TeacherTable.jsx
+++ b/screens/teachers/TeacherTable.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import 'react-native-get-random-values';
+
+import CardHeaderOut from '../../components/CardHeaderOut';
+import LoadingScreen from '../../components/LoadingScreen';
+import Screen from '../../components/Screen';
+import { httpClient, parser } from '../../utils';
+import Teacher from './Teacher';
+
+const TeacherTable = () => {
+  const [data, setData] = useState(null);
+
+  const loadData = async () => {
+    let html;
+    html = await httpClient.getTeachers();
+    if (!html) {
+      return;
+    }
+    const parsedData = parser.parseTeachers(html);
+
+    const dataGrouped = {};
+    parsedData.forEach((val) => {
+      if (dataGrouped[val.subjectUntyped]) {
+        dataGrouped[val.subjectUntyped].push(val);
+      } else {
+        dataGrouped[val.subjectUntyped] = [val];
+      }
+    });
+    setData(Object.entries(dataGrouped));
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  if (!data) return <LoadingScreen headerText="Преподаватели" />;
+
+  return (
+    <Screen headerText="Преподаватели" onUpdate={loadData}>
+      {data.map(([key, value]) => (
+        <CardHeaderOut key={key} topText={key}>
+          {value.map((teacher) => (
+            <Teacher key={teacher.name} data={teacher} />
+          ))}
+        </CardHeaderOut>
+      ))}
+    </Screen>
+  );
+};
+
+export default TeacherTable;

--- a/screens/teachers/index.js
+++ b/screens/teachers/index.js
@@ -1,0 +1,3 @@
+import TeacherTable from './TeacherTable';
+
+export default TeacherTable;

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -208,11 +208,17 @@ export default class DataParsing {
       const trimester = `${el + 1} триместр`;
       let subjects = [];
       $('.cgrldatarow', table).each((el, tr) => {
-        const subject = $(tr).find('td').eq(0).text().trim();
-        const reporting = $(tr).find('td').eq(1).text().trim();
-        const classWork = parseInt($(tr).find('td').eq(2).text().trim());
-        const soloWork = parseInt($(tr).find('td').eq(3).text().trim());
-        const total = parseInt($(tr).find('td').eq(4).text().trim());
+        const td = $(tr).find('td');
+        let isElective = td.eq(0).text().trim() === '{';
+        const fields = [];
+        for (let i = 0; i < isElective + 5; i++) {
+          fields[i] = td
+            .eq(isElective + i)
+            .text()
+            .trim();
+        }
+        const [subject, reporting, classWork, soloWork, total] = fields;
+
         subjects.push({
           subject,
           reporting,

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -16,6 +16,10 @@ export default class DataParsing {
     };
   }
 
+  getTextField(component) {
+    return component.text().trim();
+  }
+
   isLoginPage(html) {
     const $ = cheerio.load(html);
     return !!$('.login').html();
@@ -41,14 +45,14 @@ export default class DataParsing {
     $('.day', html).each((el, day) => {
       const daySelector = $(day);
       let lessons = [];
-      const date = daySelector.find('h3').text();
+      const date = this.getTextField(daySelector.find('h3'));
 
       if (!daySelector.children().last().hasClass('no_pairs')) {
         $('tr', day).each((_, tr) => {
           const trSelector = $(tr);
-          const audience = trSelector.find('.pair_info').find('.aud').text().trim();
-          const subject = trSelector.find('.pair_info').find('.dis').text().trim();
-          const time = trSelector.find('.pair_num').find('.eval').text().trim();
+          const audience = this.getTextField(trSelector.find('.pair_info').find('.aud'));
+          const subject = this.getTextField(trSelector.find('.pair_info').find('.dis'));
+          const time = this.getTextField(trSelector.find('.pair_num').find('.eval'));
           lessons.push({
             audience,
             subject,
@@ -71,9 +75,9 @@ export default class DataParsing {
     $('.teacher_info', html).each((el, teacher) => {
       const photo = $(teacher).find('img').attr('src');
       const photoTitle = $(teacher).find('img').attr('title');
-      const name = $(teacher).find('.teacher_name').text().trim();
-      const cathedra = $(teacher).find('.chair').text().trim();
-      const subject = $(teacher).find('.dis').text().trim();
+      const name = this.getTextField($(teacher).find('.teacher_name'));
+      const cathedra = this.getTextField($(teacher).find('.chair'));
+      const subject = this.getTextField($(teacher).find('.dis'));
       const [subjectUntyped, subjectType] = subject.trim().split('(');
       data.push({
         photo,
@@ -114,18 +118,20 @@ export default class DataParsing {
     let data = [];
     let cnt = -1;
     $('.nav.msg', html).each((el, announce) => {
+      const fontComponent = $(announce).find('font');
+      const bComponent = $(announce).find('b');
       if ($(announce).hasClass('repl_t')) {
         const type = 'teacher_reply';
-        let time = $(announce).find('font').eq(0).text();
-        let author = $(announce).find('b').eq(0).text();
-        let content = $(announce)
-          .find('li')
-          .contents()
-          .filter(function () {
-            return this.type === 'text';
-          })
-          .text()
-          .trim();
+        let time = this.getTextField(fontComponent.eq(0));
+        let author = this.getTextField(bComponent.eq(0));
+        let content = this.getTextField(
+          $(announce)
+            .find('li')
+            .contents()
+            .filter(function () {
+              return this.type === 'text';
+            })
+        );
         data[cnt].push({
           type,
           time,
@@ -134,15 +140,15 @@ export default class DataParsing {
         });
       } else if ($(announce).hasClass('repl_s')) {
         const type = 'student_reply';
-        let time = $(announce).find('font').eq(0).text();
-        let content = $(announce)
-          .find('li')
-          .contents()
-          .filter(function () {
-            return this.type === 'text';
-          })
-          .text()
-          .trim();
+        let time = this.getTextField(fontComponent.eq(0));
+        let content = this.getTextField(
+          $(announce)
+            .find('li')
+            .contents()
+            .filter(function () {
+              return this.type === 'text';
+            })
+        );
         data[cnt].push({
           type,
           time,
@@ -151,18 +157,21 @@ export default class DataParsing {
       } else {
         cnt += 1;
         const type = 'message';
-        let time = $(announce).find('font').eq(0).text();
-        let author = $(announce).find('b').eq(0).text();
-        let subject = $(announce).find('font').eq(1).text();
-        let theme = $(announce).find('font').eq(2).text();
-        let content = $(announce)
-          .find('li')
-          .contents()
-          .filter(function () {
-            return this.type === 'text';
-          })
-          .text()
-          .trim();
+        let author = this.getTextField(bComponent.eq(0));
+        const fields = [];
+        for (let i = 0; i < 3; i++) {
+          fields[i] = this.getTextField(fontComponent.eq(i));
+        }
+        const [time, subject, theme] = fields;
+        const content = this.getTextField(
+          $(announce)
+            .find('li')
+            .contents()
+            .filter(function () {
+              return this.type === 'text';
+            })
+        );
+
         data.push([
           {
             type,
@@ -182,12 +191,14 @@ export default class DataParsing {
     const $ = cheerio.load(html);
     let data = [];
     $('tr', html).each((el, tableRow) => {
-      if (el != 0) {
-        const number = $(tableRow).find('td').eq(0).text();
-        const time = $(tableRow).find('td').eq(1).text();
-        const subject = $(tableRow).find('td').eq(2).text();
-        const type = $(tableRow).find('td').eq(3).text();
-        const teacher = $(tableRow).find('td').eq(4).text();
+      if (el !== 0) {
+        const td = $(tableRow).find('td');
+        const fields = [];
+        for (let i = 0; i < 5; i++) {
+          fields[i] = this.getTextField(td.eq(i));
+        }
+        const [number, time, subject, type, teacher] = fields;
+
         data.push({
           number,
           time,
@@ -207,15 +218,12 @@ export default class DataParsing {
     $('.common', html).each((el, table) => {
       const trimester = `${el + 1} триместр`;
       let subjects = [];
-      $('.cgrldatarow', table).each((el, tr) => {
+      $('.cgrldatarow', table).each((_, tr) => {
         const td = $(tr).find('td');
-        let isElective = td.eq(0).text().trim() === '{';
+        let isElective = this.getTextField(td.eq(0)) === '{';
         const fields = [];
         for (let i = 0; i < isElective + 5; i++) {
-          fields[i] = td
-            .eq(isElective + i)
-            .text()
-            .trim();
+          fields[i] = this.getTextField(td.eq(isElective + i));
         }
         const [subject, reporting, classWork, soloWork, total] = fields;
 
@@ -229,7 +237,7 @@ export default class DataParsing {
       });
       data.push({
         subjects,
-        trimestr,
+        trimester,
       });
     });
     return data;
@@ -248,26 +256,34 @@ export default class DataParsing {
       $('tr', table).each((i, tr) => {
         // TODO: yeeeeeeeeeeet this shit lol
         const td = $(tr).find('td');
-        const theme = td.eq(0).text().trim();
-        const typeWork = td.eq(1).text().trim();
-        const typeControl = td.eq(2).text().trim();
-        const rawMark = td.eq(3).text().trim();
+        const fields = [];
+
+        for (let j = 0; j < 9; j++) {
+          fields[j] = this.getTextField(td.eq(j));
+        }
+        const [
+          theme,
+          typeWork,
+          typeControl,
+          rawMark,
+          passScore,
+          currentScore,
+          maxScore,
+          date,
+          teacher,
+        ] = fields;
+
         const mark = parseFloat(rawMark);
         const isAbsent = rawMark === 'н';
-        const passScore = parseFloat(td.eq(4).text().trim());
-        const currentScore = parseFloat(td.eq(5).text().trim());
-        const maxScore = parseFloat(td.eq(6).text().trim());
-        const date = td.eq(7).text().trim();
-        const teacher = td.eq(8).text().trim();
         info.push({
           theme,
           typeWork,
           typeControl,
           mark,
           isAbsent,
-          passScore,
-          currentScore,
-          maxScore,
+          passScore: parseFloat(passScore),
+          currentScore: parseFloat(currentScore),
+          maxScore: parseFloat(maxScore),
           date,
           teacher,
         });
@@ -279,13 +295,12 @@ export default class DataParsing {
       });
     });
     $('h3', html).each((el, name) => {
-      const subject = $(name).text();
-      data.subjects[el].subject = subject;
+      data.subjects[el].subject = this.getTextField($(name));
     });
 
     const subMenu = $('.submenu').last();
     $('.submenu-item', subMenu).each((i, el) => {
-      if (!$('a', el).text()) {
+      if (!this.getTextField($('a', el))) {
         data.currentTrimester = i + 1;
         return false;
       }
@@ -312,13 +327,15 @@ export default class DataParsing {
 
     // Получение информации о студенте
 
-    const rawData = $('.span12').text().trim();
+    const rawData = this.getTextField($('.span12'));
     const [rawName, speciality, form, year] = rawData.split('\n').map((string) => string.trim());
     const [name1, name2, name3] = rawName.split(' ');
-    data.student.name = `${name1} ${name2} ${name3}`;
-    data.student.speciality = speciality;
-    data.student.educationForm = form;
-    data.student.year = year;
+    data.student = {
+      name: `${name1} ${name2} ${name3}`,
+      speciality,
+      educationForm: form,
+      year,
+    };
 
     if (parseGroupJournal) {
       data.student.group = $('.span9').find('h3').text().split(' ')[1];
@@ -331,9 +348,9 @@ export default class DataParsing {
         const span = $(el);
         const href = span.parent().attr('href');
         if (href === 'stu.announce') {
-          data.announceCount = parseInt(span.text());
+          data.announceCount = parseInt(this.getTextField(span));
         } else if (href === 'stu.teacher_notes') {
-          data.messageCount = parseInt(span.text());
+          data.messageCount = parseInt(this.getTextField(span));
         }
       });
 

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -70,14 +70,18 @@ export default class DataParsing {
     let data = [];
     $('.teacher_info', html).each((el, teacher) => {
       const photo = $(teacher).find('img').attr('src');
-      const name = $(teacher).find('.teacher_name').text();
-      const cathedra = $(teacher).find('.chair').text();
-      const subject = $(teacher).find('.dis').text();
+      const photoTitle = $(teacher).find('img').attr('title');
+      const name = $(teacher).find('.teacher_name').text().trim();
+      const cathedra = $(teacher).find('.chair').text().trim();
+      const subject = $(teacher).find('.dis').text().trim();
+      const [subjectUntyped, subjectType] = subject.trim().split('(');
       data.push({
         photo,
         name,
         cathedra,
-        subject,
+        subjectUntyped,
+        subjectType: subjectType.slice(0, -1),
+        photoTitle,
       });
     });
     return data;
@@ -218,8 +222,8 @@ export default class DataParsing {
         });
       });
       data.push({
-        trimester,
         subjects,
+        trimestr,
       });
     });
     return data;


### PR DESCRIPTION
Дисциплины по выбору в учебном плане объеденины знаком `{`,  теперь это поле будет пропущено при парсинге
Так же проведен рефакторинг парсера с использованием циклов для обратботки однотипных полей и деструкторов
PR ребейз от #27 