### PR TITLE
fix: compare raw points w/ raw pass points

### DIFF
--- a/screens/signs/CardSign.jsx
+++ b/screens/signs/CardSign.jsx
@@ -60,9 +60,9 @@ const getSubjectPointsStyle = (subject, totalPoint) => {
   if (subject.info.length === 0) return styles.colorNoMark;
 
   let textStyle;
-  subject.info.forEach(({ passScore, points, currentScore, isAbsent, isIntroductionWork }) => {
+  subject.info.forEach(({ passScore, points, isAbsent, isIntroductionWork }) => {
     if (!isIntroductionWork) {
-      if (isAbsent || currentScore < passScore) textStyle = styles.colorMark2;
+      if (isAbsent || points < passScore) textStyle = styles.colorMark2;
       else if (Number.isNaN(points) && !isAbsent) textStyle = styles.colorNoMark;
     }
   });

--- a/screens/signs/Subject.jsx
+++ b/screens/signs/Subject.jsx
@@ -27,7 +27,7 @@ const SubjectCheckPoint = ({ data }) => (
         <Text
           style={
             (Number.isNaN(info.points) && info.isAbsent || info.points < info.passScore) &&
-              (info.maxScore !== 0.0)
+              (!info.isIntroductionWork)
               ? styles.markFail
               : styles.markNeutral
           }


### PR DESCRIPTION
currentScore отвечает за переведенные баллы (100-балльная система), а points и passScore задаются в свободной форме (могут быть 100 за одну КТ)
Из-за чего неверно отображалось
![image](https://github.com/Damego/ETIS-mobile/assets/53531892/36e7c29e-9506-4949-af21-b6f5c53e3ddb)
