### PR TITLE
feat: missing data screen

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -28,12 +28,11 @@ const EmptyCard = () => {
 };
 
 interface LoadingScreenProps {
-  headerText?: string;
-  onRefresh?(): Promise<void>
+  onRefresh?(): Promise<void>;
 }
 
-const LoadingScreen = ({ headerText, onRefresh }: LoadingScreenProps) => (
-  <Screen headerText={headerText} onUpdate={onRefresh}>
+const LoadingScreen = ({ onRefresh }: LoadingScreenProps) => (
+  <Screen onUpdate={onRefresh}>
     <View style={{ marginTop: '10%' }} />
     <EmptyCard />
     <EmptyCard />

--- a/src/components/MissingDataScreen.tsx
+++ b/src/components/MissingDataScreen.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { useGlobalStyles } from '../hooks';
+import { fontSize } from '../utils/texts';
+
+const styles = StyleSheet.create({
+  cardView: {
+    padding: '2%',
+    alignItems: 'center',
+    flex: 1,
+    display: 'flex',
+    marginBottom: '3%',
+    borderRadius: 10,
+  },
+  text: {
+    fontWeight: 'bold',
+  },
+});
+
+const MissingDataScreen = () => {
+  const globalStyles = useGlobalStyles();
+
+  return (
+    <View style={[styles.cardView]}>
+      <Text style={[fontSize.large, styles.text, globalStyles.textColor]}>
+        Данные временно недоступны Попробуйте попытку позже
+      </Text>
+    </View>
+  );
+};
+
+export default MissingDataScreen;

--- a/src/parser/timeTable.ts
+++ b/src/parser/timeTable.ts
@@ -32,7 +32,7 @@ export default function parseTimeTable(html) {
     last: parseInt(week.last().text()),
     type: getWeekType(currentWeek),
     holidayDates: null,
-    dates: null
+    dates: null,
   };
 
   const dates = getTextField($('.week-select').children().last());
@@ -40,8 +40,8 @@ export default function parseTimeTable(html) {
     const [weekStart, weekEnd, holidayStart, holidayEnd] = dates.match(dateRegex);
     weekInfo.dates = {
       start: weekStart,
-      end: weekEnd
-    }
+      end: weekEnd,
+    };
     weekInfo.holidayDates = {
       start: holidayStart,
       end: holidayEnd,

--- a/src/screens/shortTeachPlan/ShortTeachPlan.tsx
+++ b/src/screens/shortTeachPlan/ShortTeachPlan.tsx
@@ -3,13 +3,13 @@ import { ToastAndroid } from 'react-native';
 
 import LoadingScreen from '../../components/LoadingScreen';
 import Screen from '../../components/Screen';
+import { getWrappedClient } from '../../data/client';
 import { useAppDispatch, useAppSelector } from '../../hooks';
+import { GetResultType, RequestType } from '../../models/results';
 import { ISessionTeachPlan } from '../../models/teachPlan';
 import { setAuthorizing } from '../../redux/reducers/authSlice';
+import CalendarSchedule from './CalendarSchedule';
 import SessionCard from './SessionCard';
-import CalendarSchedule from "./CalendarSchedule";
-import { getWrappedClient } from '../../data/client';
-import { GetResultType, RequestType } from '../../models/results';
 
 const ShortTeachPlan = () => {
   const dispatch = useAppDispatch();

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -15,6 +15,12 @@ export enum ErrorCode {
   authError,
 }
 
+export enum LoadingState {
+  loading,
+  loaded,
+  missingData,
+}
+
 export interface HTTPError {
   code: ErrorCode;
   message: string;


### PR DESCRIPTION
Для основных экранов приложения уведомления _Произошла ошибка..._ недостаточно, необходимо более явно показать, что данные недоступны - добавил менюшку с соотв. увдомлением, но получилось не очень.. нужна помощь в design
![Screenshot_2023-08-17-00-32-50-18_f73b71075b1de7323614b647fe394240](https://github.com/Damego/ETIS-mobile/assets/53531892/852a131d-30d1-451f-8ec3-ad7eabbc8a83)

Возможно требуется во все экраны ввести такой функционал