### PR TITLE
chore: simplify subject regexp

### DIFF
--- a/src/parser/teachers.ts
+++ b/src/parser/teachers.ts
@@ -4,10 +4,8 @@ import { ITeacher, TeacherType } from '../models/teachers';
 import { executeRegex } from '../utils/sentry';
 import { getTextField } from './utils';
 
-/* https://regex101.com/r/gvUVMt/11 */
-/* duplicated in sentry.ts */
-const subjectRegex =
-  /([а-яА-Я\w\s":.,+#-]+\s?(?:\([а-яА-Я\w\s]+\) )?(?:\[[а-яА-Я\w\s,+-]+] )*)\(([а-яА-Я\s,.-]+)\)/s;
+/* https://regex101.com/r/gvUVMt/14 */
+const subjectRegex = /(.*)\s\(([а-я]+(?:,\s[а-я]+)*)\)/s;
 const numberRegex = /(\d+)/s;
 
 const groupTeachers = (data: ITeacher[]) => {

--- a/src/screens/shortTeachPlan/ShortTeachPlan.tsx
+++ b/src/screens/shortTeachPlan/ShortTeachPlan.tsx
@@ -5,7 +5,6 @@ import NoData from '../../components/NoData';
 import Screen from '../../components/Screen';
 import { useClient } from '../../data/client';
 import useQuery from '../../hooks/useQuery';
-import { checkSubjectNames } from '../../utils/sentry';
 import CalendarSchedule from './CalendarSchedule';
 import SessionCard from './SessionCard';
 
@@ -13,9 +12,6 @@ const ShortTeachPlan = () => {
   const client = useClient();
   const { data, isLoading, refresh } = useQuery({
     method: client.getTeachPlanData,
-    after: (result) => {
-      checkSubjectNames(result.data);
-    },
   });
 
   if (isLoading) return <LoadingScreen onRefresh={refresh} />;

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -1,7 +1,5 @@
 import * as SentryExpo from 'sentry-expo';
 
-import { ISessionTeachPlan } from '../models/teachPlan';
-
 export default () => {
   if (__DEV__) return;
 
@@ -27,21 +25,6 @@ export default () => {
     });
   }
 };
-
-const subjectRegex = /([а-яА-Я\w\s":.,+#-]+(?: \([а-яА-Я\w\s]+\))?(?: \[[а-яА-Я\w\s,]+])*)/s;
-export const checkSubjectNames = (teachPlan: ISessionTeachPlan[]) => {
-  const incorrectDisciplines = teachPlan
-    ?.map((session) => session.disciplines.map((discipline) => discipline.name))
-    .flat()
-    .filter((name) => !subjectRegex.test(name));
-  if (incorrectDisciplines?.length !== 0) {
-    SentryExpo.React.captureMessage(
-      `Disciplines mismatched w/ regex: ${JSON.stringify(incorrectDisciplines)}`,
-      'error'
-    );
-  }
-};
-
 export const reportParserError = (error) => {
   if (!__DEV__) SentryExpo.React.captureException(error);
 };


### PR DESCRIPTION
в связи с невозможностью установить все возможные комбинации символов в названии учебных дисциплин пришли к тому, что бы упростить проверку до вилкарда