### PR TITLE
fix: fetch data if student have duty for session

### DIFF
--- a/src/hooks/useSignsQuery.ts
+++ b/src/hooks/useSignsQuery.ts
@@ -57,10 +57,18 @@ const useSignsQuery = () => {
   }, [pointsData, marksQuery.data]);
 
   const loadSession = (session: number) => {
+    const hasDuty = marksQuery.data.find(
+      (sessionMarks) =>
+        sessionMarks.session === session &&
+        !!sessionMarks.disciplines.find(
+          (discipline) => ['2', 'незачет'].includes(discipline.mark)
+        )
+    );
+
     update({
       data: session,
       requestType:
-        session < currentSession || fetchedSessions.current.includes(session)
+        (session < currentSession || fetchedSessions.current.includes(session)) && !hasDuty
           ? RequestType.tryCache
           : RequestType.tryFetch,
     });

--- a/src/hooks/useSignsQuery.ts
+++ b/src/hooks/useSignsQuery.ts
@@ -60,9 +60,7 @@ const useSignsQuery = () => {
     const hasDuty = marksQuery.data.find(
       (sessionMarks) =>
         sessionMarks.session === session &&
-        !!sessionMarks.disciplines.find(
-          (discipline) => ['2', 'незачет'].includes(discipline.mark)
-        )
+        !!sessionMarks.disciplines.find((discipline) => ['2', 'незачет'].includes(discipline.mark))
     );
 
     update({


### PR DESCRIPTION
Если у студента имеется задолженность по одному из предметов в триместре/семестре, то при клике в оценках на данный период будет происходить запрос данных в ЕТИС, а не получение их из кэша, как это было ранее, так как это запутывало студентов