### PR TITLE
feat: add audience timetable

### DIFF
--- a/src/api/psutech/api.ts
+++ b/src/api/psutech/api.ts
@@ -54,7 +54,7 @@ export const getAudienceTimetable = async (audienceId: number, week: number) => 
     params: { week },
   });
 
-  const {data} = res;
+  const { data } = res;
 
   data.weekInfo = data.week_info;
 

--- a/src/api/psutech/api.ts
+++ b/src/api/psutech/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { IAudience, ITimeTable } from '~/models/timeTable';
 
 import { IFaculty, IGroup, IPeriodWeek, ITeacher, PeriodTypes } from './types';
 
@@ -40,5 +41,22 @@ export const getPeriodWeek = async (
 
 export const getGroupById = async (groupId: string) => {
   const res = await inst.get<IGroup>(`/groups/${groupId}`);
+  return res.data;
+};
+
+export const searchAudience = async (query: string, building: string) => {
+  const res = await inst.get<IAudience[]>('/audience/search', { params: { query, building } });
+  return res.data;
+};
+
+export const getAudienceTimetable = async (audienceId: number, week: number) => {
+  const res = await inst.get<ITimeTable>(`/audience/${audienceId}/timetable/`, {
+    params: { week },
+  });
+
+  const {data} = res;
+
+  data.weekInfo = data.week_info;
+
   return res.data;
 };

--- a/src/components/timetable/dayTimetable/DayTimetable.tsx
+++ b/src/components/timetable/dayTimetable/DayTimetable.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import PagerView from 'react-native-pager-view';
 import CenteredText from '~/components/CenteredText';
 import TimetablePages from '~/components/timetable/dayTimetable/components/TimetablePages';

--- a/src/components/timetable/dayTimetable/components/Pair.tsx
+++ b/src/components/timetable/dayTimetable/components/Pair.tsx
@@ -45,6 +45,13 @@ const Pair = ({ pair }: { pair: IPair }) => {
             </React.Fragment>
           );
         })}
+        {pair.event && (
+          <View>
+            <Text style={styles.eventTitleText}>Мероприятие "{pair.event.name}"</Text>
+            <Text style={styles.eventNameText}>{pair.event.contact_info}</Text>
+            <Text style={styles.eventNameText}>{pair.event.department}</Text>
+          </View>
+        )}
       </View>
     </View>
   );
@@ -71,5 +78,12 @@ const styles = StyleSheet.create({
   timeEndText: {
     fontSize: 16,
     color: '#808080',
+  },
+  eventTitleText: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  eventNameText: {
+    fontSize: 16,
   },
 });

--- a/src/components/timetable/dayTimetable/components/TimetablePages.tsx
+++ b/src/components/timetable/dayTimetable/components/TimetablePages.tsx
@@ -16,7 +16,10 @@ const Page = ({ day }: { day: ITimeTableDay }) => {
   return (
     <View style={styles.pairsList}>
       {!day.pairs.length && <NoPairs />}
-      {day.pairs.map((pair) => (!!pair.lessons.length || !!pair.event) && <Pair pair={pair} key={pair.position} />)}
+      {day.pairs.map(
+        (pair) =>
+          (!!pair.lessons.length || !!pair.event) && <Pair pair={pair} key={pair.position} />
+      )}
     </View>
   );
 };

--- a/src/components/timetable/dayTimetable/components/TimetablePages.tsx
+++ b/src/components/timetable/dayTimetable/components/TimetablePages.tsx
@@ -16,7 +16,7 @@ const Page = ({ day }: { day: ITimeTableDay }) => {
   return (
     <View style={styles.pairsList}>
       {!day.pairs.length && <NoPairs />}
-      {day.pairs.map((pair) => !!pair.lessons.length && <Pair pair={pair} key={pair.position} />)}
+      {day.pairs.map((pair) => (!!pair.lessons.length || !!pair.event) && <Pair pair={pair} key={pair.position} />)}
     </View>
   );
 };

--- a/src/components/timetable/weekTimetable/components/DatesContainer.tsx
+++ b/src/components/timetable/weekTimetable/components/DatesContainer.tsx
@@ -3,14 +3,15 @@ import React from 'react';
 import { Text, View } from 'react-native';
 import { useGlobalStyles } from '~/hooks';
 import { WeekDates } from '~/models/timeTable';
+import { parseDate } from '~/parser/utils';
 import { fontSize } from '~/utils/texts';
 
 const DatesContainer = ({ dates }: { dates: WeekDates }) => {
   const globalStyles = useGlobalStyles();
   if (!dates) return;
 
-  const startDate = dayjs(dates.start, 'DD.MM.YYYY').format('D MMMM');
-  const endDate = dayjs(dates.end, 'DD.MM.YYYY').format('D MMMM');
+  const startDate = parseDate(dates.start).format('D MMMM');
+  const endDate = parseDate(dates.end).format('D MMMM');
 
   return (
     <View style={{ marginVertical: '2%', justifyContent: 'center', alignItems: 'center' }}>

--- a/src/components/timetable/weekTimetable/components/Pair.tsx
+++ b/src/components/timetable/weekTimetable/components/Pair.tsx
@@ -37,6 +37,13 @@ const Pair = ({ pair, date }: { pair: IPair; date: dayjs.Dayjs }) => {
             />
           );
         })}
+        {pair.event && (
+          <View>
+            <Text style={styles.eventTitleText}>Мероприятие "{pair.event.name}"</Text>
+            <Text style={styles.eventNameText}>{pair.event.contact_info}</Text>
+            <Text style={styles.eventNameText}>{pair.event.department}</Text>
+          </View>
+        )}
       </View>
     </View>
   );
@@ -99,4 +106,9 @@ const styles = StyleSheet.create({
     gap: 4,
     flexDirection: 'row',
   },
+  eventTitleText: {
+    ...fontSize.medium,
+    fontWeight: '500',
+  },
+  eventNameText: {},
 });

--- a/src/hooks/useTimetable.ts
+++ b/src/hooks/useTimetable.ts
@@ -51,11 +51,12 @@ const useTimetable = ({
 
   const updateData = (weekInfo: WeekInfo) => {
     if (preSelectedDate) {
-      setTimetable((prev) => ({
-        ...prev,
-        selectedDate: preSelectedDate,
+      setTimetable({
+        currentDate,
+        currentWeek,
+        selectedDate: preSelectedDate.clone(),
         selectedWeek: weekInfo.selected ?? selectedWeek,
-      }));
+      });
       preSelectedDate = null;
     } else if (weekInfo.selected !== null) {
       const startWeekDate = parseDate(weekInfo.dates.start);

--- a/src/models/timeTable.ts
+++ b/src/models/timeTable.ts
@@ -65,6 +65,8 @@ export interface ISubject {
 }
 
 export interface IAudience {
+  // Идентификатор аудитории в ЕТИС. Доступно только в расписании аудитории
+  id?: number;
   // Необработанная строка аудитории
   string: string;
   // Номер аудитории
@@ -122,6 +124,9 @@ export interface ITimeTable {
 
   // Преподаватель. Только в расписании преподавателей
   teacher?: ITeacher;
+
+  // Аудитория. Только в расписании аудиторий
+  audience?: IAudience;
 
   // Доступно только для авторизованных студентов
   icalToken?: string;

--- a/src/models/timeTable.ts
+++ b/src/models/timeTable.ts
@@ -100,6 +100,15 @@ export interface ILesson {
   shortGroups?: string[];
 }
 
+export interface IEvent {
+  // Названия мероприятия
+  name: string;
+  // Контактная информация
+  contact_info: string;
+  // Подразделение, отвечающее за данное мероприятие
+  department: string;
+}
+
 export interface IPair {
   // Позиция пары
   position: number;
@@ -107,6 +116,9 @@ export interface IPair {
   time: string;
   // Список занятий на эту пару
   lessons: ILesson[];
+
+  // Мероприятие. Доступно только в расписании аудитории
+  event?: IEvent;
 }
 
 export interface ITimeTableDay {

--- a/src/navigation/EducationNavigation.tsx
+++ b/src/navigation/EducationNavigation.tsx
@@ -8,6 +8,8 @@ import AppSettingsButton from '~/navigation/headerButtons/AppSettingsButton';
 import { EducationStackParamList } from '~/navigation/types';
 import Absences from '~/screens/etis/absences';
 import AccountSettings from '~/screens/etis/accountSettings/AccountSettings';
+import AudienceTimetable from '~/screens/etis/audienceTimetable/AudienceTimetable';
+import SelectAudience from '~/screens/etis/audienceTimetable/SelectAudience';
 import Auth from '~/screens/etis/auth/Auth';
 import BellSchedule from '~/screens/etis/bellSchedule/BellSchedule';
 import CathedraTimetable from '~/screens/etis/cathedraTimetable/CathedraTimetable';
@@ -134,6 +136,16 @@ const EducationNavigation = () => {
             name={'DisciplineEducationalComplexTheme'}
             component={DisciplineEducationalComplexTheme}
             options={{ title: 'УМК' }}
+          />
+          <Stack.Screen
+            name={'SelectAudience'}
+            component={SelectAudience}
+            options={{ title: 'Аудитория' }}
+          />
+          <Stack.Screen
+            name={'AudienceTimetable'}
+            component={AudienceTimetable}
+            options={{ title: 'Расписание' }}
           />
         </>
       )}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,7 +9,7 @@ import { IAvailableCertificate } from '~/models/certificate';
 import { IDisciplineEducationalComplexThemeLink } from '~/models/disciplineEducationalComplex';
 import { IMessage } from '~/models/messages';
 import { ITeachPlanDiscipline } from '~/models/teachPlan';
-import { ILesson } from '~/models/timeTable';
+import { IAudience, ILesson } from '~/models/timeTable';
 
 // Список экранов для основного стека
 export type RootStackParamList = {
@@ -107,6 +107,8 @@ export type EducationStackParamList = {
   ChangeEmail: { sendVerificationMail: boolean };
   // Расписание преподавателей/кафедр
   CathedraTimetable: { teacherId?: string; cathedraId?: string };
+  SelectAudience: undefined;
+  AudienceTimetable: { audience: IAudience };
 };
 
 // Список экранов с нижними табами

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -4,7 +4,12 @@ import { LessonTypes } from '~/models/other';
 
 export const getTextField = (component: cheerio.Cheerio): string => component.text().trim();
 
-export const parseDate = (date: string) => dayjs(date, 'DD.MM.YYYY');
+export const parseDate = (date: string) => {
+  if (date.length === 8) {
+    return dayjs(date, 'DD.MM.YY');
+  }
+  return dayjs(date, 'DD.MM.YYYY');
+};
 export const parseDatetime = (date: string) => dayjs(date, 'DD.MM.YYYY HH:mm:ss');
 
 export const getAsNumber = (str: string, defaultValue: number = null): number | null => {

--- a/src/screens/etis/audienceTimetable/AudienceTimetable.tsx
+++ b/src/screens/etis/audienceTimetable/AudienceTimetable.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import React, { useEffect } from 'react';
+import { getAudienceTimetable } from '~/api/psutech/api';
+import LoadingScreen, { LoadingContainer } from '~/components/LoadingScreen';
+import Screen from '~/components/Screen';
+import Text from '~/components/Text';
+import TimetableContainer from '~/components/timetable/TimetableContainer';
+import useTimetable from '~/hooks/useTimetable';
+import { EducationStackScreenProps } from '~/navigation/types';
+import { fontSize } from '~/utils/texts';
+
+const AudienceTimetable = ({ route }: EducationStackScreenProps<'AudienceTimetable'>) => {
+  const { audience } = route.params;
+
+  const timetable = useTimetable({ onRequestUpdate: (week) => setFetchWeek(week) });
+  const [fetchWeek, setFetchWeek] = React.useState<number>(timetable.selectedWeek);
+
+  const { data, isLoading } = useQuery({
+    queryFn: () => getAudienceTimetable(audience.id, fetchWeek),
+    queryKey: ['aud-timetable', fetchWeek, audience.id],
+  });
+
+  useEffect(() => {
+    if (data) {
+      timetable.updateData(data.weekInfo);
+    }
+  }, [data]);
+
+  return (
+    <Screen>
+      {data && (
+        <Text style={[fontSize.large, { fontWeight: 'bold', alignSelf: 'center' }]}>
+          Аудитория: {data.audience.string}
+        </Text>
+      )}
+
+      <TimetableContainer
+        timetable={timetable}
+        data={data}
+        isLoading={isLoading}
+        loadingComponent={() => <LoadingContainer />}
+      />
+    </Screen>
+  );
+};
+
+export default AudienceTimetable;

--- a/src/screens/etis/audienceTimetable/SelectAudience.tsx
+++ b/src/screens/etis/audienceTimetable/SelectAudience.tsx
@@ -1,0 +1,98 @@
+import { AntDesign } from '@expo/vector-icons';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { searchAudience } from '~/api/psutech/api';
+import BorderLine from '~/components/BorderLine';
+import ClickableText from '~/components/ClickableText';
+import Text from '~/components/Text';
+import { useGlobalStyles } from '~/hooks';
+import { useAppTheme } from '~/hooks/theme';
+import { IAudience } from '~/models/timeTable';
+import { EducationStackScreenProps } from '~/navigation/types';
+import SearchInput from '~/screens/start/components/SearchInput';
+import { fontSize } from '~/utils/texts';
+
+const SelectAudience = ({ navigation }: EducationStackScreenProps) => {
+  const theme = useAppTheme();
+  const globalStyles = useGlobalStyles();
+
+  const [query, setQuery] = React.useState('');
+  const [selectedAudience, setSelectedAudience] = React.useState<IAudience>(null);
+  const [selectedBuilding, setSelectedBuilding] = React.useState(null);
+
+  const { data } = useQuery({
+    queryFn: () => searchAudience(query, selectedBuilding),
+    queryKey: ['aud-search', query, selectedBuilding],
+  });
+
+  const selectAudience = (audience: IAudience) => () => {
+    setSelectedAudience(audience);
+  };
+
+  const handleConfirm = () => {
+    navigation.navigate('AudienceTimetable', { audience: selectedAudience });
+  };
+
+  return (
+    <View style={styles.screenContainer}>
+      <View style={styles.searchWrapper}>
+        <SearchInput value={query} onValueChange={setQuery} />
+      </View>
+
+      {data?.map((audience, index) => (
+        <View key={audience.id}>
+          <ClickableText
+            onPress={selectAudience(audience)}
+            viewStyle={styles.teacherItem}
+            textStyle={fontSize.medium}
+            iconRight={
+              audience.id === selectedAudience?.id && (
+                <AntDesign name={'checkcircle'} color={theme.colors.primary} size={20} />
+              )
+            }
+          >
+            {audience.number}
+          </ClickableText>
+          {index !== data.length - 1 && <BorderLine />}
+        </View>
+      ))}
+
+      {selectedAudience !== null && (
+        <TouchableOpacity
+          onPress={handleConfirm}
+          style={[styles.button, globalStyles.primaryBackgroundColor, globalStyles.borderRadius]}
+        >
+          <Text colorVariant={'primaryContrast'} style={fontSize.big}>
+            Выбрать
+          </Text>
+          <Text colorVariant={'primaryContrast'}>({selectedAudience.number})</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+export default SelectAudience;
+
+const styles = StyleSheet.create({
+  screenContainer: {
+    marginHorizontal: '4%',
+    flex: 1,
+  },
+  searchWrapper: {
+    marginVertical: '5%',
+  },
+  teacherItem: {
+    paddingVertical: '4%',
+    justifyContent: 'space-between',
+  },
+  button: {
+    position: 'absolute',
+    bottom: '2%',
+    left: 0,
+    right: 0,
+    padding: '4%',
+    alignItems: 'center',
+  },
+});

--- a/src/screens/etis/main/more/MoreScreens.tsx
+++ b/src/screens/etis/main/more/MoreScreens.tsx
@@ -1,4 +1,4 @@
-import { AntDesign } from '@expo/vector-icons';
+import { AntDesign, Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { Image } from 'expo-image';
 import React from 'react';
@@ -64,6 +64,11 @@ const SCREENS: ScreenT[][] = [
       title: 'Анкетирование',
       icon: (color) => <AntDesign name={'copy1'} size={ICON_SIZE} color={color} />,
       screenName: 'SessionQuestionnaireList',
+    },
+    {
+      title: 'Расписание аудиторий',
+      icon: (color) => <Ionicons name={'business-outline'} size={ICON_SIZE} color={color} />,
+      screenName: 'SelectAudience',
     },
   ],
 ];

--- a/src/utils/texts.ts
+++ b/src/utils/texts.ts
@@ -75,6 +75,8 @@ export const formatAudience = (lesson: ILesson) => {
     return lesson.distancePlatform.name;
   }
 
+  if (!audience) return;
+
   return audience.number && audience.building && audience.floor
     ? `ауд. ${audience.number} (${audience.building} корпус, ${audience.floor} этаж)`
     : audience.string;


### PR DESCRIPTION
Добавляет расписание аудиторий.

Используется внутреннее апи, которое отправляет множество запросов в ЕТИС, собирая по кусочкам расписание.

![image](https://github.com/user-attachments/assets/125bc92a-43a1-46e4-af1e-e58a8d841852)
![image](https://github.com/user-attachments/assets/de7aac30-563b-4ada-8751-83719374c3a7)
![image](https://github.com/user-attachments/assets/ff1327c1-dae0-4ae5-9051-3d54dc40e965)
