### PR TITLE
fix: sentry reports

### DIFF
--- a/src/hooks/useTimetable.ts
+++ b/src/hooks/useTimetable.ts
@@ -58,7 +58,7 @@ const useTimetable = ({
         selectedWeek: weekInfo.selected ?? selectedWeek,
       });
       preSelectedDate = null;
-    } else if (weekInfo.selected !== null) {
+    } else if (weekInfo.selected !== null && weekInfo.dates !== null) {
       const startWeekDate = parseDate(weekInfo.dates.start);
 
       setTimetable((prev) => ({

--- a/src/screens/etis/digitalResources/DigitalResources.tsx
+++ b/src/screens/etis/digitalResources/DigitalResources.tsx
@@ -13,12 +13,10 @@ import useQuery from '~/hooks/useQuery';
 import { fontSize } from '~/utils/texts';
 import { groupItems } from '~/utils/utils';
 
-const Field = ({ value }: { value: string }) => {
+const Field = ({ value }: { value?: string }) => {
   const globalStyles = useGlobalStyles();
 
-  const copyValue = () => {
-    Clipboard.setStringAsync(value);
-  };
+  const copyValue = () => Clipboard.setStringAsync(value);
 
   return (
     <View
@@ -33,9 +31,11 @@ const Field = ({ value }: { value: string }) => {
       ]}
     >
       <Text selectable>{value}</Text>
-      <TouchableOpacity onPress={copyValue}>
-        <Feather name={'copy'} size={18} color={globalStyles.textColor.color} />
-      </TouchableOpacity>
+      (value &&
+        <TouchableOpacity onPress={copyValue}>
+          <Feather name={'copy'} size={18} color={globalStyles.textColor.color} />
+        </TouchableOpacity>
+      )
     </View>
   );
 };

--- a/src/screens/etis/digitalResources/DigitalResources.tsx
+++ b/src/screens/etis/digitalResources/DigitalResources.tsx
@@ -32,9 +32,9 @@ const Field = ({ value }: { value?: string }) => {
     >
       <Text selectable>{value}</Text>
       (value &&
-        <TouchableOpacity onPress={copyValue}>
-          <Feather name={'copy'} size={18} color={globalStyles.textColor.color} />
-        </TouchableOpacity>
+      <TouchableOpacity onPress={copyValue}>
+        <Feather name={'copy'} size={18} color={globalStyles.textColor.color} />
+      </TouchableOpacity>
       )
     </View>
   );

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -40,7 +40,7 @@ const readJSONFromDocuments = async (fileName: string, defaultValue: any) => {
     return JSON.parse(stringData);
   } catch (e) {
     await saveJSONToDocuments(defaultValue, fileName);
-    return JSON.parse(defaultValue);
+    return defaultValue;
   }
 };
 

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -37,11 +37,11 @@ const readJSONFromDocuments = async (fileName: string, defaultValue: any) => {
 
   try {
     stringData = await readAsStringAsync(`${documentDirectory}${fileName}`);
+    return JSON.parse(stringData);
   } catch (e) {
     await saveJSONToDocuments(defaultValue, fileName);
-    stringData = await readAsStringAsync(`${documentDirectory}${fileName}`);
+    return JSON.parse(defaultValue);
   }
-  return JSON.parse(stringData);
 };
 
 const saveDisciplineInfo = (data: IDisciplineInfo[]) =>

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -42,8 +42,8 @@ export const executeRegex = (
 };
 
 export const ignoreErrors = [
-  "sp-react-native-in-app-updates",
-  "ExpoBackgroundFetch.registerTaskAsync",
-  "ExpoFontLoader",
-  "OutOfMemoryError",
-]
+  'sp-react-native-in-app-updates',
+  'ExpoBackgroundFetch.registerTaskAsync',
+  'ExpoFontLoader',
+  'OutOfMemoryError',
+];

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -21,6 +21,7 @@ export default () => {
           ]
         : [],
       debug: __DEV__, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
+      ignoreErrors,
     });
   }
 };
@@ -39,3 +40,10 @@ export const executeRegex = (
   }
   return result;
 };
+
+export const ignoreErrors = [
+  "sp-react-native-in-app-updates",
+  "ExpoBackgroundFetch.registerTaskAsync",
+  "ExpoFontLoader",
+  "OutOfMemoryError",
+]


### PR DESCRIPTION
Исправлено несколько ошибок пойманных sentry
* [sentry/65](https://etismobile.sentry.io/issues/6125169192/events/b517a73961e74ce1b375d17460b310b3/) не понятно, либо произошел обрыв соединения и дошли некорректные http-данные, либо сайт действительно отдает без даты
* [sentry/62](https://etismobile.sentry.io/issues/6125106886/events/41c5802e92ed48a7a2e2427290143cca/) вероятно на диске сохранились non-json данные, из-за чего теперь загрузка ломается. теперь будет форсировать значения по умолчанию
 * [sentry/67](https://etismobile.sentry.io/issues/6125230593/events/7e756086479547b794e95f51365d2577/) при попытке скопировать пустую строку бросается исключение, хоть функционал не ломается. кнопка была отключена для пустых **Цифровых ресурсов**. Требуется тест
 * так же были отключены события на исключения `in-app-update`, `ExpoFetch`, `ExpoFont`, `OOM` за не информативность и перегруженность 